### PR TITLE
BZ#847399 - changes needed around admin users

### DIFF
--- a/recipes/aeolus/manifests/conductor.pp
+++ b/recipes/aeolus/manifests/conductor.pp
@@ -137,11 +137,16 @@ class aeolus::conductor inherits aeolus {
                 require         => Aeolus::Rails::Migrate::Db[migrate_aeolus_database]}
 
     # Create default admin user
+    include aeolus::profiles::common
+    aeolus::conductor::destroy_temp_admins{ "before" : }
     aeolus::conductor::site_admin{"admin":
                     email => 'root@localhost.localdomain',
                     password => "password",
                     first_name => 'Administrator',
-                    last_name => ''}
+                    last_name => '',
+                    require => Aeolus::Conductor::Destroy_temp_admins["before"]}
+
+    Aeolus::Conductor::Site_admin <| |> -> Aeolus::Conductor::Temp_admin[$aeolus::profiles::common::temp_admin_login]
 
  ### Setup sshd for deltacloud
   package { "openssh-server": ensure => installed }

--- a/recipes/aeolus/manifests/conductor/destroy_temp_admins.pp
+++ b/recipes/aeolus/manifests/conductor/destroy_temp_admins.pp
@@ -1,8 +1,8 @@
-define aeolus::conductor::destroy_temp_admin{
-  exec{"destroy_temp_admin":
+define aeolus::conductor::destroy_temp_admins {
+  exec{"destroy_temp_admin-${name}":
     cwd         => '/usr/share/aeolus-conductor',
     environment => "RAILS_ENV=production",
-    command     => "/usr/bin/rake dc:destroy_user[${name}]",
+    command     => "/usr/bin/rake dc:destroy_users_by_pattern[temporary-administrative-user-%]",
     logoutput   => true,
     require     => Rails::Seed::Db["seed_aeolus_database"]
   }

--- a/recipes/aeolus/manifests/profiles/common.pp
+++ b/recipes/aeolus/manifests/profiles/common.pp
@@ -37,7 +37,7 @@ class aeolus::profiles::common {
 
   aeolus::conductor::logout{$temp_admin_login:}
 
-  aeolus::conductor::destroy_temp_admin{$temp_admin_login :
+  aeolus::conductor::destroy_temp_admins{ "after" :
     require => Aeolus::Conductor::Logout[$temp_admin_login]}
 
   Aeolus::Conductor::Provider <| |> -> Aeolus::Conductor::Logout <| |>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=847399

This replaces destroy_temp_admin with destroy_temp_admins, which uses
the new dc:destroy_users_by_pattern rake task to destroy _all_
temporary users.

In addition, we now destroy temp admins twice during a given configure
run:
- Before attempting to create a site_admin user
- At the end, as before

Also, the site admin is created before the temp admin.  All of this
collectively ensures that the site admin is successfully created if
needed.  Before it was possible for the temp admin to be created first
(or for "stale" temp admins to be in the database) which would prevent
the site admin from being created.
