### PR TITLE
Support for configuration of Kerberos SSO authentication

### DIFF
--- a/conf/README
+++ b/conf/README
@@ -11,3 +11,6 @@ IMPORTANT NOTE:  https is on by default, but no other security is in place
 to ensure that components on different machines can interact in a secure
 fashion.  This is on the roadmap, but not currently in place.  Segregate
 services at your own risk.
+
+Kerberos can be used only with https enabled. Your system has to be
+configured for kerberos authentication.

--- a/conf/default_configure
+++ b/conf/default_configure
@@ -12,10 +12,13 @@
 #apart from https on the web server for conductor, you should
 #consider intermachine communications insecure.  Securing
 #intermachine service calls is on the roadmap.
-#
+
+#Kerberos can be used only with https enabled. Your system has to be
+#configured for kerberos authentication.
 ---
 parameters:
   enable_https: true
+  enable_kerberos: false
   enable_security: false
   package_provider: rpm
 classes:

--- a/recipes/aeolus/templates/aggregator-httpd-ssl.conf
+++ b/recipes/aeolus/templates/aggregator-httpd-ssl.conf
@@ -13,6 +13,7 @@ NameVirtualHost *:443
   SSLCertificateKeyFile /etc/pki/tls/private/localhost.key
   ProxyPreserveHost Off
   RequestHeader set X_FORWARDED_PROTO 'https'
+  RequestHeader set X_FORWARDED_USER %{REMOTE_USER}s
 
   Timeout 5400
   ProxyTimeout 5400
@@ -45,6 +46,13 @@ ProxyPassReverse /conductor/stylesheets !
 ProxyPassReverse /conductor/errors !
 ProxyPassReverse /conductor/javascripts !
 ProxyPassReverse /conductor/fonts !
+
+<% if enable_kerberos -%>
+        AuthType Kerberos
+        AuthName "Kerberos Login"
+        Krb5KeyTab /etc/krb5.keytab
+        Require valid-user
+<% end -%>
 
 </VirtualHost>
 

--- a/recipes/aeolus/templates/aggregator-httpd-ssl.conf
+++ b/recipes/aeolus/templates/aggregator-httpd-ssl.conf
@@ -48,10 +48,10 @@ ProxyPassReverse /conductor/javascripts !
 ProxyPassReverse /conductor/fonts !
 
 <% if enable_kerberos -%>
-        AuthType Kerberos
-        AuthName "Kerberos Login"
-        Krb5KeyTab /etc/krb5.keytab
-        Require valid-user
+AuthType Kerberos
+AuthName "Kerberos Login"
+Krb5KeyTab /etc/krb5.keytab
+Require valid-user
 <% end -%>
 
 </VirtualHost>

--- a/recipes/apache/manifests/init.pp
+++ b/recipes/apache/manifests/init.pp
@@ -22,7 +22,14 @@ class apache {
 	  package { "mod_ssl":
                       ensure => installed,
                       source => $package_provider }
-  }
+
+      if $enable_kerberos {
+             package { "mod_auth_kerb":
+                          ensure => installed,
+                          source => $package_provider }
+      }
+
+   }
 
   # if selinux is enabled and we want to use mod_proxy, we need todo this
   exec{'permit-http-networking':


### PR DESCRIPTION
Basic support of puppet configuration for Kerberos SSO. If the value enable_kerberos
is set to true, puppet will install needed modules for apache and provide basic configuration,
which can be extended by the system administrator as needed. After successful authentication,
apache rewrites the REMOTE_USER header as X_FORWARDED_USER to be used by conductor.
