### PR TITLE
RM3740 Configurable Conductor session timeout

### DIFF
--- a/recipes/aeolus/templates/conductor-settings.yml
+++ b/recipes/aeolus/templates/conductor-settings.yml
@@ -19,3 +19,6 @@
   :oauth:
     :consumer_key: <%= imagefactory_oauth_user %>
     :consumer_secret: <%= imagefactory_oauth_password %>
+
+:session:
+  :timeout: 15 # minutes


### PR DESCRIPTION
This is needed to set things up correctly for Conductor from current master.

It is directly related this recent change in Conductor:
https://github.com/aeolusproject/conductor/pull/19

Tested on F17 by building packages of Configure and Conductor and running aeolus-configure. The only thing I had to do was remove rubygem(ldap_fluff) dependency from Conductor rpm to be able to install it. Aeolus-configure command then ran ok and so did Conductor.
