### PR TITLE
Disable httpd proxy retry timeout to conductor

### DIFF
--- a/recipes/aeolus/templates/aggregator-httpd-ssl.conf
+++ b/recipes/aeolus/templates/aggregator-httpd-ssl.conf
@@ -39,7 +39,7 @@ ProxyPass /conductor/stylesheets !
 ProxyPass /conductor/errors !
 ProxyPass /conductor/javascripts !
 ProxyPass /conductor/fonts !
-ProxyPass /conductor http://localhost:3000/conductor
+ProxyPass /conductor http://localhost:3000/conductor retry=0
 ProxyPassReverse /conductor http://localhost:3000/conductor
 ProxyPassReverse /conductor/graphics !
 ProxyPassReverse /conductor/stylesheets !

--- a/recipes/aeolus/templates/aggregator-httpd.conf
+++ b/recipes/aeolus/templates/aggregator-httpd.conf
@@ -33,7 +33,7 @@ ProxyPass /conductor/stylesheets !
 ProxyPass /conductor/errors !
 ProxyPass /conductor/javascripts !
 ProxyPass /conductor/fonts !
-ProxyPass /conductor http://localhost:3000/conductor
+ProxyPass /conductor http://localhost:3000/conductor retry=0
 ProxyPassReverse /conductor http://localhost:3000/conductor
 ProxyPassReverse /conductor/graphics !
 ProxyPassReverse /conductor/stylesheets !


### PR DESCRIPTION
(for https://bugzilla.redhat.com/show_bug.cgi?id=854382)

If a proxied request fails, the default behavior of httpd is to defer
requests for 60 seconds.  This change ensures that when a proxied
request fails, all future requests are still sent to the backend
instead of being deferred.
