### PR TITLE
BZ#855351 - Use selboolean type instead of exec for managing selinux boolean

### DIFF
--- a/recipes/apache/manifests/init.pp
+++ b/recipes/apache/manifests/init.pp
@@ -32,15 +32,14 @@ class apache {
    }
 
   # if selinux is enabled and we want to use mod_proxy, we need todo this
-  exec{'permit-http-networking':
-         command => 'setsebool -P httpd_can_network_connect 1',
-         unless   => "test 'Disabled' = `getenforce` ||
-                      (getsebool httpd_can_network_connect | grep -q 'on$')"
+  selboolean{ 'httpd_can_network_connect':
+    persistent => true,
+    value      => on,
   }
 
 	service { "httpd":
 		ensure     => running,
-		require    => [Package["httpd"], Exec['permit-http-networking']],
+		require    => [Package["httpd"], Selboolean['httpd_can_network_connect']],
 		hasrestart => true,
     hasstatus  => true,
     enable     => true


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=855351

Puppet supplies a selboolean type to manipulate selinux booleans.
There's no need to use exec to shell out to setsebool.  In the
particular case of the referenced bug, the exec method times out; the
selboolean type will not time out.
