### PR TITLE
Stop mispelling 'Stoping'

### DIFF
--- a/bin/aeolus-restart-services
+++ b/bin/aeolus-restart-services
@@ -32,8 +32,8 @@ services = %w(mongod iwhd postgresql httpd deltacloud-core libvirtd aeolus-condu
 def perform(action, svcs)
   action = action.to_s
   svcs.map do |script|
-    puts "\n#{action.capitalize}ing #{script} ..."
     cmd = "service #{script} #{action}"
+    puts "\n# #{cmd} ..."
     out = `#{cmd}`
     if $?.to_i == 0
       puts " \e[1;32mSuccess:\e[0m #{out.strip}"


### PR DESCRIPTION
I've had this locally patched for sometime, but neglected to send up for review.  It's looks horrible when running 'aeolus-restart-services' to see an obvious misspelling consistently displayed.  This patch will no longer emit 'Stoping' when stopping services.  Instead, the command ('service foo stop') will be displayed.

Thanks,
James
