### PR TITLE
Fix login and logout

### DIFF
--- a/recipes/aeolus/manifests/conductor/login.pp
+++ b/recipes/aeolus/manifests/conductor/login.pp
@@ -2,7 +2,7 @@
 define aeolus::conductor::login($password){
   web_request{ "${name}-conductor-login":
     post         => 'https://localhost/conductor/user_session',
-    parameters  => { 'login'    => "$name", 'password' => "$password",
+    parameters  => { 'username'    => "$name", 'password' => "$password",
                      'commit'                 => 'submit' },
     returns     => '200',
     follow      => true,

--- a/recipes/aeolus/manifests/conductor/logout.pp
+++ b/recipes/aeolus/manifests/conductor/logout.pp
@@ -1,9 +1,7 @@
 # log out of the aeolus conductor
 define aeolus::conductor::logout(){
   web_request{ "${name}-conductor-logout":
-    post         => 'https://localhost/conductor/logout',
-    parameters  => { 'login'    => "admin", 'password' => "password",
-                     'commit'                 => 'submit' },
+    get         => 'https://localhost/conductor/logout',
     returns     => '200',
     follow      => true,
     use_cookies_at => "/tmp/aeolus-$name",


### PR DESCRIPTION
https://github.com/aeolusproject/conductor/pull/52 Introduces the change from User.login to User.username in conductor. This patch reflects these changes for aeolus-configure.

Logout is done via Get and doesn't need any parameters.

I have tested this with the conductor built from pull request 52^ and latest built aeolus-configure. 

Although I am running into other errors when running the latest build aeolus-configure that are not related to this patch:

```
err: /Stage[main]/Apache/Selboolean[httpd_can_network_connect]: Could not evaluate: Execution of '/usr/sbin/getsebool httpd_can_network_connect' returned 1: /usr/sbin/getsebool:  SELinux is disabled

notice: /Stage[main]/Apache/Service[httpd]: Dependency Selboolean[httpd_can_network_connect] has failures: true
```

and then

```
notice: /Stage[main]/Aeolus::Profiles::Common/Aeolus::Conductor::Login[temporary-administrative-user-d0122d5b5adf7eb6f7c7fa8f31d2c685d859de3fbbce9af2]/Exec[decrement_login_counter]/returns: executed successfully
notice: /Stage[main]/Aeolus::Profiles::Common/Aeolus::Conductor::Hwp[small-x86_64]/Web_request[hwp-small-x86_64]/post: post changed '' to 'https://localhost/conductor/hardware_profiles'
err: /Stage[main]/Aeolus::Profiles::Mock/Aeolus::Conductor::Provider[mock]/Web_request[provider-mock]/post: change from  to https://localhost/conductor/providers.xml failed: An exception was raised when invoking web request: Invalid HTTP Return Code: 400,
                               was expecting one of 200
notice: /Stage[main]/Aeolus::Profiles::Mock/Aeolus::Conductor::Provider::Account[mock]/Web_request[provider-account-mock]: Dependency Web_request[provider-mock] has failures: true
```
