### PR TITLE
BZ#859521 - errors with configure if provider already exists

### DIFF
--- a/recipes/aeolus/manifests/conductor/provider.pp
+++ b/recipes/aeolus/manifests/conductor/provider.pp
@@ -11,7 +11,7 @@ define aeolus::conductor::provider($deltacloud_driver="",$url="", $deltacloud_pr
     use_cookies_at => "/tmp/aeolus-${admin_login}",
     log_to      => '/tmp/configure-provider-request.log',
     only_log_errors => true,
-    unless      => { 'get'             => 'https://localhost/conductor/providers.xml',
+    unless      => { 'get'             => 'https://localhost/conductor/providers.xml?with_data=true',
                      'contains'        => "/providers/provider/name[text() = '$name']" },
     require    => [Service['aeolus-conductor'], Exec['grant_temp_admin_privs'], Exec['deltacloud-core-startup-wait']]
   }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=859521

Pass 'with_data' to the providers API when checking for existing
providers.  Otherwise, only stubs which don't contain the name
attribute are returned.

(Depends on https://github.com/aeolusproject/conductor/pull/73)
