### PR TITLE
`aeolus-services restart` does not restart conductor-delayed_job

### DIFF
--- a/bin/aeolus-services
+++ b/bin/aeolus-services
@@ -35,7 +35,7 @@ To show status of aeolus services please use aeolus-check-services.
 end
 
 # ordered as in rc.d
-$services = %w(mongod iwhd postgresql httpd deltacloud-core libvirtd aeolus-conductor conductor-dbomatic imagefactory ntpd)
+$services = %w(mongod iwhd postgresql httpd deltacloud-core libvirtd aeolus-conductor conductor-delayed_job conductor-dbomatic imagefactory ntpd)
 
 $action_messages = {'status' => 'Checking status of',
                     'start'  => 'Starting',


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=864098

Added conductor-delayed_job to list of services in aeolus-services script.
