### PR TITLE
Preserve LDAP configuration when reinvoking aeolus-configure

### DIFF
--- a/bin/aeolus-cleanup
+++ b/bin/aeolus-cleanup
@@ -80,7 +80,7 @@ do
     
     puppet /usr/share/aeolus-configure/modules/aeolus/aeolus.pp \
        --modulepath=/usr/share/aeolus-configure/modules/ \
-       --external_nodes "/bin/sh /usr/share/aeolus-configure/modules/aeolus/aeolus-node ${x}_cleanup" --node_terminus exec \
+       --external_nodes "/usr/bin/ruby /usr/share/aeolus-configure/modules/aeolus/aeolus-node ${x}_cleanup" --node_terminus exec \
        --logdest=/var/log/aeolus-configure/aeolus-cleanup.log \
        --logdest=console \
        $LOGLEVEL \

--- a/bin/aeolus-configure
+++ b/bin/aeolus-configure
@@ -91,7 +91,7 @@ do
     fi
     puppet /usr/share/aeolus-configure/modules/aeolus/aeolus.pp \
        --modulepath=/usr/share/aeolus-configure/modules/ \
-       --external_nodes "/bin/sh /usr/share/aeolus-configure/modules/aeolus/aeolus-node ${x}_configure" --node_terminus exec \
+       --external_nodes "/usr/bin/ruby /usr/share/aeolus-configure/modules/aeolus/aeolus-node ${x}_configure" --node_terminus exec \
        --logdest=/var/log/aeolus-configure/aeolus-configure.log \
        --logdest=console \
        $LOGLEVEL \

--- a/bin/aeolus-node
+++ b/bin/aeolus-node
@@ -1,6 +1,6 @@
-#! /bin/sh
+#! /usr/bin/ruby
 
-#   Copyright 2011 Red Hat, Inc.
+#   Copyright 2012 Red Hat, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -14,7 +14,39 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-CAT=/bin/cat
-NODE_DIR=/etc/aeolus-configure/nodes
+require 'yaml'
 
-$CAT $NODE_DIR/$1
+NODE_DIR='/etc/aeolus-configure/nodes'
+ldap_configure_file = File.join(NODE_DIR, 'ldap_configure')
+profile_file = File.join(NODE_DIR, ARGV[0])
+
+[ldap_configure_file, profile_file].each do |f|
+  unless File.exists?(f)
+    STDERR.puts "No such file or directory - #{f}"
+    exit!(1)
+  end
+end
+
+begin
+  ldap = YAML::load_file(ldap_configure_file)['parameters']['enable_ldap']
+rescue NoMethodError
+  STDERR.puts "#{ldap_configure_file} does not contain a value for " \
+              "'enable_ldap' under the 'parameters' section"
+  exit!(1)
+rescue => e
+  STDERR.puts e.message
+  exit!(1)
+end
+
+begin
+  profile = YAML::load_file(profile_file)
+rescue => e
+  STDERR.puts e.message
+  exit!(1)
+end
+
+profile['parameters'] ||= {}
+profile['parameters']['enable_ldap'] = ldap
+puts YAML::dump(profile)
+
+

--- a/conf/ldap_configure
+++ b/conf/ldap_configure
@@ -1,0 +1,6 @@
+# This file is included by other top-level profiles.  You should not
+# use this profile directly (It has no classes so it won't do anything
+# anyway.)
+
+parameters:
+  enable_ldap: false

--- a/recipes/aeolus/manifests/conductor.pp
+++ b/recipes/aeolus/manifests/conductor.pp
@@ -29,7 +29,6 @@ class aeolus::conductor inherits aeolus {
       mode    => 640, owner => 'root', group => 'aeolus'}
 
     file{"/etc/ldap_fluff.yml":
-      content => template("aeolus/etc-ldap_fluff.yml"),
       require => Package['aeolus-conductor'],
       mode    => 640, owner => 'root', group => 'aeolus'}
 

--- a/recipes/aeolus/templates/conductor-settings.yml
+++ b/recipes/aeolus/templates/conductor-settings.yml
@@ -2,7 +2,7 @@
 
 :auth:
   # supported strategies: database, ldap
-  :strategy: database
+  :strategy: <%= enable_ldap ? "ldap" : "database" %>
 :groups:
   # allows locally-managed groups
   :enable_local: true


### PR DESCRIPTION
This adds a new configure "pseudo-profile" at /etc/aeolus-configure/nodes/ldap_configure.  To enable ldap mode, one simply needs to edit this file and set enable_ldap to true.  This pseudo-profile will be included into all other profiles automatically.

Additionally, we'll stop half-managing the contents of /etc/ldap_fluff.yml.

Fixes: RHBZ#868313
