### PR TITLE
create common pseudo-profile

### DIFF
--- a/bin/aeolus-node
+++ b/bin/aeolus-node
@@ -17,10 +17,19 @@
 require 'yaml'
 
 NODE_DIR='/etc/aeolus-configure/nodes'
-ldap_configure_file = File.join(NODE_DIR, 'ldap_configure')
 profile_file = File.join(NODE_DIR, ARGV[0])
+common_file = case
+              when ARGV[0].end_with?('_configure')
+                File.join(NODE_DIR, 'common_configure')
+              when ARGV[0].end_with?('_cleanup')
+                File.join(NODE_DIR, 'common_cleanup')
+              else
+                STDERR.puts "Unknown profile type for #{ARGV[0]}, " \
+                            "should be one of {configure,cleanup}"
+                exit!(1)
+              end
 
-[ldap_configure_file, profile_file].each do |f|
+[common_file, profile_file].each do |f|
   unless File.exists?(f)
     STDERR.puts "No such file or directory - #{f}"
     exit!(1)
@@ -28,17 +37,7 @@ profile_file = File.join(NODE_DIR, ARGV[0])
 end
 
 begin
-  ldap = YAML::load_file(ldap_configure_file)['parameters']['enable_ldap']
-rescue NoMethodError
-  STDERR.puts "#{ldap_configure_file} does not contain a value for " \
-              "'enable_ldap' under the 'parameters' section"
-  exit!(1)
-rescue => e
-  STDERR.puts e.message
-  exit!(1)
-end
-
-begin
+  common_params = YAML::load_file(common_file)['parameters']
   profile = YAML::load_file(profile_file)
 rescue => e
   STDERR.puts e.message
@@ -46,7 +45,7 @@ rescue => e
 end
 
 profile['parameters'] ||= {}
-profile['parameters']['enable_ldap'] = ldap
+profile['parameters'] = common_params.merge(profile['parameters'])
 puts YAML::dump(profile)
 
 

--- a/conf/common_cleanup
+++ b/conf/common_cleanup
@@ -3,4 +3,6 @@
 # anyway.)
 
 parameters:
-  enable_ldap: false
+  enable_https: true
+  enable_kerberos: false
+  enable_security: false

--- a/conf/common_configure
+++ b/conf/common_configure
@@ -1,0 +1,10 @@
+# This file is included by other top-level profiles.  You should not
+# use this profile directly (It has no classes so it won't do anything
+# anyway.)
+
+parameters:
+  enable_https: true
+  enable_kerberos: false
+  enable_ldap: false
+  enable_security: false
+  package_provider: rpm

--- a/conf/conductor_cleanup
+++ b/conf/conductor_cleanup
@@ -1,8 +1,5 @@
 #conductor-only cleanup specification
 ---
 parameters:
-  enable_https: true
-  enable_kerberos: false
-  enable_security: false
 classes:
 - aeolus::conductor::disabled

--- a/conf/default_cleanup
+++ b/conf/default_cleanup
@@ -7,9 +7,6 @@
 #desire and it will take precedence over this.
 ---
 parameters:
-  enable_https: true
-  enable_kerberos: false
-  enable_security: false
 # Uncomment these to clean up RHEV
 #  rhevm_nfs_server: nfs.server.com
 #  rhevm_nfs_export: /export/export_domain

--- a/conf/default_configure
+++ b/conf/default_configure
@@ -17,10 +17,6 @@
 #configured for kerberos authentication.
 ---
 parameters:
-  enable_https: true
-  enable_kerberos: false
-  enable_security: false
-  package_provider: rpm
 classes:
 - aeolus::conductor
 - aeolus::image-factory

--- a/conf/deltacloud_cleanup
+++ b/conf/deltacloud_cleanup
@@ -1,8 +1,5 @@
 #deltacloud-only cleanup specification
 ---
 parameters:
-  enable_https: true
-  enable_kerberos: false
-  enable_security: false
 classes:
 - aeolus::deltacloud::disabled

--- a/conf/deltacloud_configure
+++ b/conf/deltacloud_configure
@@ -1,4 +1,3 @@
 parameters:
-  package_provider: rpm
 classes:
 - aeolus::profiles::deltacloud

--- a/conf/ec2_configure
+++ b/conf/ec2_configure
@@ -1,10 +1,6 @@
 # ec2 setup configuration.
 ---
 parameters:
-  enable_https: true
-  enable_kerberos: false
-  enable_security: false
-  package_provider: rpm
 classes:
 - aeolus::conductor
 - aeolus::image-factory

--- a/conf/imagebuilder_configure
+++ b/conf/imagebuilder_configure
@@ -1,5 +1,4 @@
 parameters:
-  package_provider: rpm
 classes:
 - aeolus::image-factory
 - aeolus::iwhd

--- a/conf/imagefactory_cleanup
+++ b/conf/imagefactory_cleanup
@@ -1,8 +1,5 @@
 #imagefactory-only cleanup specification
 ---
 parameters:
-  enable_https: true
-  enable_kerberos: false
-  enable_security: false
 classes:
 - aeolus::image-factory::disabled

--- a/conf/imagefactory_configure
+++ b/conf/imagefactory_configure
@@ -1,4 +1,3 @@
 parameters:
-  package_provider: rpm
 classes:
 - aeolus::image-factory

--- a/conf/iwhd_cleanup
+++ b/conf/iwhd_cleanup
@@ -1,8 +1,5 @@
 #iwhd-only cleanup specification
 ---
 parameters:
-  enable_https: true
-  enable_kerberos: false
-  enable_security: false
 classes:
 - aeolus::iwhd::disabled

--- a/conf/iwhd_configure
+++ b/conf/iwhd_configure
@@ -13,9 +13,5 @@
 #intermachine service calls is on the roadmap.
 ---
 parameters:
-  enable_https: true
-  enable_kerberos: false
-  enable_security: false
-  package_provider: rpm
 classes:
 - aeolus::iwhd

--- a/conf/mock_configure
+++ b/conf/mock_configure
@@ -1,10 +1,6 @@
 # mock setup configuration.
 ---
 parameters:
-  enable_https: true
-  enable_kerberos: false
-  enable_security: false
-  package_provider: rpm
 classes:
 - aeolus::conductor
 - aeolus::image-factory

--- a/conf/rhevm_cleanup
+++ b/conf/rhevm_cleanup
@@ -1,9 +1,6 @@
 #rhevm-only cleanup specification
 ---
 parameters:
-  enable_https: true
-  enable_kerberos: false
-  enable_security: false
   package_provider: rpm
 classes:
   aeolus::profiles::rhevm::disabled:

--- a/conf/rhevm_configure
+++ b/conf/rhevm_configure
@@ -1,9 +1,5 @@
 ---
 parameters:
-  enable_https: true
-  enable_kerberos: false
-  enable_security: false
-  package_provider: rpm
 classes:
   aeolus::conductor:
   aeolus::image-factory:

--- a/conf/vsphere_configure
+++ b/conf/vsphere_configure
@@ -1,9 +1,5 @@
 ---
 parameters:
-  enable_https: true
-  enable_kerberos: false
-  enable_security: false
-  package_provider: rpm
 classes:
   aeolus::conductor:
   aeolus::image-factory:

--- a/conf/wui_configure
+++ b/conf/wui_configure
@@ -1,5 +1,4 @@
 parameters:
-  package_provider: rpm
 classes:
 - aeolus::conductor
 - aeolus::profiles::conductor


### PR DESCRIPTION
#20 factors ldap configuration out into a "pseudo-profile".  Really we should factor out all of the other common stuff as well into a common_configure profile and be done with it in one go.  Specifically this stuff:

  enable_https: true
  enable_kerberos: false
  enable_security: false
  package_provider: rpm
