### PR TITLE
Replacing hard-coded passwords with hiera

### DIFF
--- a/recipes/aeolus/hiera.yaml
+++ b/recipes/aeolus/hiera.yaml
@@ -1,0 +1,6 @@
+:hierarchy:
+  - common
+:backends:
+  - yaml
+:yaml:
+:datadir: 'hieradata'

--- a/recipes/aeolus/hieradata/common.yaml
+++ b/recipes/aeolus/hieradata/common.yaml
@@ -1,0 +1,3 @@
+---
+aeolus_password: v23zj59an
+aeolus_site_admin_password: password

--- a/recipes/aeolus/manifests/conductor.pp
+++ b/recipes/aeolus/manifests/conductor.pp
@@ -109,7 +109,7 @@ class aeolus::conductor inherits aeolus {
       notify      => Service["postgresql"]
     }
     postgres::user{"aeolus":
-                     password => "v23zj59an",
+                     password => hiera('aeolus_password'),
                      roles    => "CREATEDB",
                      require  => Service["postgresql"] }
 

--- a/recipes/aeolus/manifests/conductor.pp
+++ b/recipes/aeolus/manifests/conductor.pp
@@ -145,7 +145,7 @@ class aeolus::conductor inherits aeolus {
     aeolus::conductor::destroy_temp_admins{ "before" : }
     aeolus::conductor::site_admin{"admin":
                     email => 'root@localhost.localdomain',
-                    password => "password",
+                    password => hiera('aeolus_site_admin_password'),
                     first_name => 'Administrator',
                     last_name => '',
                     require => Aeolus::Conductor::Destroy_temp_admins["before"]}


### PR DESCRIPTION
Greetings, 
I am a security researcher, who is looking for security smells in Puppet scripts. 
I noticed two instances of hard-coded passwords in  aeolus-configure/recipes/aeolus/manifests/conductor.pp, which are against the best practices 
recommended by Common Weakness Enumeration (CWE) [https://cwe.mitre.org/data/definitions/259.html] and also by other security practitioners.

I have added hiera support to mitigate this smell. 

Feedback is welcome. 